### PR TITLE
👷 Reorder pnpm setup before Node.js in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,13 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v5
         with:
           node-version: 22.x
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
 
       - name: Install Dependencies
         run: pnpm install


### PR DESCRIPTION
Moved the pnpm setup step before the Node.js setup step in the GitHub Actions release workflow to ensure proper tool initialization order.