### PR TITLE
(docs): README 문서 개선

### DIFF
--- a/packages/oxc-formatter-config/README.md
+++ b/packages/oxc-formatter-config/README.md
@@ -1,6 +1,6 @@
 # oxc-formatter-config
 
-> Prettier with OXC plugin을 사용한 코드 포맷팅 설정
+이 패키지는 Prettier와 oxc 플러그인(`@prettier/plugin-oxc`)을 사용한 코드 포맷팅 설정을 제공합니다.
 
 ## Installation
 
@@ -9,8 +9,6 @@ pnpm add -D prettier @prettier/plugin-oxc @cocopalm/oxc-formatter-config
 ```
 
 ## How to use
-
-이 패키지는 Prettier의 OXC 플러그인(`@prettier/plugin-oxc`)을 사용하여 코드를 포맷팅합니다.
 
 ### .prettierrc.mjs 설정하기
 

--- a/packages/oxc-linter-config/README.md
+++ b/packages/oxc-linter-config/README.md
@@ -1,11 +1,11 @@
 # oxc-linter-config
 
-> ⚠️ oxc linter는 현재 활발히 개발 진행중인 라이브러리입니다. 그로 인해 버전간의 주요 변경사항이 존재할 수 있습니다.
+이 패키지는 oxc-linter용 공통 린트 설정을 제공합니다.
 
 ## Installation
 
 ```bash
-pnpm add oxlint @cocopalm/oxc-linter-config
+pnpm add -D oxlint @cocopalm/oxc-linter-config
 ```
 
 ## How to use


### PR DESCRIPTION
## Description

두 패키지의 README 문서를 개선하였습니다.

### 변경 사항

**oxc-formatter-config**
- 소개 문구를 더 명확하게 개선
- 중복된 설명 문구 제거하여 가독성 향상

**oxc-linter-config**
- 경고 문구를 간결한 소개 문구로 변경
- 설치 명령어에 `-D` 플래그 추가하여 devDependencies로 설치하도록 개선

### 동기 및 맥락

사용자가 패키지를 처음 접했을 때 더 명확하고 간결한 정보를 제공하기 위해 README 문서를 개선하였습니다.