### PR TITLE
(oxc-linter-config): eslint-plugin-react-hooks peer 의존성 추가 및 CHANGELOG 포맷 개선

### DIFF
--- a/.changeset/changelog.js
+++ b/.changeset/changelog.js
@@ -1,0 +1,10 @@
+/** @type {import('@changesets/types').ChangelogFunctions} */
+const changelogFunctions = {
+  getReleaseLine: async (changeset) => {
+    const summary = changeset.summary
+    return `\n\n${summary}`
+  },
+  getDependencyReleaseLine: async () => '',
+}
+
+module.exports = changelogFunctions

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": "./.changeset/changelog.js",
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/kjiklt-admj-tzivqq.md
+++ b/.changeset/kjiklt-admj-tzivqq.md
@@ -1,0 +1,8 @@
+---
+"@cocopalm/oxc-linter-config": patch
+---
+
+### New Features
+
+- Added `eslint-plugin-react-hooks` as an optional peer dependency (`^6.0.0`) for `/react-compiler` config users.
+- Updated README with React Compiler setup example including the required `eslint-plugin-react-hooks` installation step.

--- a/packages/oxc-linter-config/README.ko.md
+++ b/packages/oxc-linter-config/README.ko.md
@@ -107,7 +107,26 @@ export default defineConfig({
    })
    ```
 
-3. **Node.js 프로젝트**
+3. **React Compiler를 사용하는 React 프로젝트**
+
+   > **참고:** `/react-compiler` 설정을 사용하려면 `eslint-plugin-react-hooks` 패키지가 필요합니다:
+   >
+   > ```bash
+   > pnpm add -D eslint-plugin-react-hooks
+   > ```
+
+   ```ts
+   import { defineConfig } from 'oxlint'
+   import baseConfig from '@cocopalm/oxc-linter-config/base'
+   import reactConfig from '@cocopalm/oxc-linter-config/react'
+   import reactCompilerConfig from '@cocopalm/oxc-linter-config/react-compiler'
+
+   export default defineConfig({
+     extends: [baseConfig, reactConfig, reactCompilerConfig],
+   })
+   ```
+
+4. **Node.js 프로젝트**
 
    ```ts
    import { defineConfig } from 'oxlint'

--- a/packages/oxc-linter-config/README.md
+++ b/packages/oxc-linter-config/README.md
@@ -107,7 +107,26 @@ export default defineConfig({
    })
    ```
 
-3. **Node.js projects**
+3. **React projects with React Compiler**
+
+   > **Note:** Using the `/react-compiler` config requires `eslint-plugin-react-hooks` to be installed:
+   >
+   > ```bash
+   > pnpm add -D eslint-plugin-react-hooks
+   > ```
+
+   ```ts
+   import { defineConfig } from 'oxlint'
+   import baseConfig from '@cocopalm/oxc-linter-config/base'
+   import reactConfig from '@cocopalm/oxc-linter-config/react'
+   import reactCompilerConfig from '@cocopalm/oxc-linter-config/react-compiler'
+
+   export default defineConfig({
+     extends: [baseConfig, reactConfig, reactCompilerConfig],
+   })
+   ```
+
+4. **Node.js projects**
 
    ```ts
    import { defineConfig } from 'oxlint'

--- a/packages/oxc-linter-config/package.json
+++ b/packages/oxc-linter-config/package.json
@@ -49,6 +49,12 @@
     "typescript": "^6.0.2"
   },
   "peerDependencies": {
-    "oxlint": "^1.57.0"
+    "oxlint": "^1.57.0",
+    "eslint-plugin-react-hooks": "^6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "eslint-plugin-react-hooks": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
## Description

- `eslint-plugin-react-hooks`를 optional peer dependency로 추가하여 `/react-compiler` 설정 사용자에게 필요한 의존성을 명시
- README(영문/한글)에 React Compiler 설정 사용 예시 및 `eslint-plugin-react-hooks` 설치 안내 추가
- CHANGELOG에서 commit hash가 포함되지 않도록 커스텀 changelog 함수 적용