### PR TITLE
(oxc-linter-config): eslint-plugin-react-hooks peer 범위 v7로 확장

### DIFF
--- a/.changeset/react-hooks-v7-peer.md
+++ b/.changeset/react-hooks-v7-peer.md
@@ -1,0 +1,5 @@
+---
+"@cocopalm/oxc-linter-config": patch
+---
+
+- Expand `eslint-plugin-react-hooks` peer dependency range to `^6.0.0 || ^7.0.0` to support the new major version.

--- a/packages/oxc-linter-config/package.json
+++ b/packages/oxc-linter-config/package.json
@@ -2,8 +2,20 @@
   "name": "@cocopalm/oxc-linter-config",
   "version": "0.2.2",
   "description": "oxc linter configuration",
-  "author": "puffcocos",
+  "keywords": [
+    "config",
+    "linter",
+    "oxc"
+  ],
   "license": "MIT",
+  "author": "puffcocos",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/puffcocos/oxc-config-kit"
+  },
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "main": "./dist/base.mjs",
   "exports": {
@@ -24,24 +36,12 @@
       "types": "./dist/react-compiler.d.mts"
     }
   },
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsdown"
-  },
-  "keywords": [
-    "oxc",
-    "linter",
-    "config"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/puffcocos/oxc-config-kit"
-  },
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "scripts": {
+    "build": "tsdown"
   },
   "devDependencies": {
     "oxlint": "^1.57.0",
@@ -49,8 +49,8 @@
     "typescript": "^6.0.2"
   },
   "peerDependencies": {
-    "oxlint": "^1.57.0",
-    "eslint-plugin-react-hooks": "^6.0.0"
+    "eslint-plugin-react-hooks": "^6.0.0 || ^7.0.0",
+    "oxlint": "^1.57.0"
   },
   "peerDependenciesMeta": {
     "eslint-plugin-react-hooks": {


### PR DESCRIPTION
## Description

`@cocopalm/oxc-linter-config`의 `eslint-plugin-react-hooks` peer dependency 범위를 `^6.0.0`에서 `^6.0.0 || ^7.0.0`으로 확장하여 새로 릴리스된 v7 메이저 버전을 함께 지원합니다.

### 변경 사항

- `packages/oxc-linter-config/package.json`
  - `peerDependencies.eslint-plugin-react-hooks` 범위를 `^6.0.0 || ^7.0.0`으로 확장
  - package.json 필드 순서를 관례(이름/메타 → exports → publishConfig → scripts → deps)에 맞게 재정렬 (기능 영향 없음)
- `.changeset/react-hooks-v7-peer.md`
  - `@cocopalm/oxc-linter-config` patch bump changeset 추가

### 동기 및 컨텍스트

`eslint-plugin-react-hooks` v7이 릴리스되면서 기존 v6만 허용하던 peer 범위로는 v7 사용자가 peer 경고를 보게 되어 범위를 확장합니다. Breaking change가 아니므로 patch bump로 처리했습니다.

### Dependencies

- 없음