### PR TITLE
(deps): eslint-plugin-react-hooks peer 범위 확장 lockfile 동기화

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
   packages/oxc-linter-config:
     dependencies:
       eslint-plugin-react-hooks:
-        specifier: ^6.0.0
+        specifier: ^6.0.0 || ^7.0.0
         version: 6.1.1(eslint@9.39.4)
     devDependencies:
       oxlint:


### PR DESCRIPTION
## Description

#73에서 `@cocopalm/oxc-linter-config`의 `eslint-plugin-react-hooks` peer dependency 범위를 `^6.0.0 || ^7.0.0`으로 확장했으나, `pnpm-lock.yaml`의 specifier가 함께 업데이트되지 않아 후속으로 동기화합니다.

### 변경 사항

- `pnpm-lock.yaml`
  - `packages/oxc-linter-config`의 `eslint-plugin-react-hooks` specifier를 `^6.0.0`에서 `^6.0.0 || ^7.0.0`으로 갱신 (설치된 버전 `6.1.1`은 그대로)

### 동기 및 컨텍스트

package.json과 lockfile의 specifier가 불일치하면 `pnpm install --frozen-lockfile`(CI)에서 lockfile이 오래된 것으로 간주되어 실패할 수 있어 후속 동기화가 필요합니다.

### Dependencies

- #73 (머지됨)