### PR TITLE
fix: update author and repository URL

### DIFF
--- a/.changeset/update-author-repo-url.md
+++ b/.changeset/update-author-repo-url.md
@@ -1,7 +1,0 @@
----
-"@cocopalm/oxc-formatter-config": patch
-"@cocopalm/oxc-linter-config": patch
----
-
-- Update `author` field in `package.json` from `puffcocos` to `wjdgus09`.
-- Update `repository.url` in `package.json` to `https://github.com/wjdgus09/oxc-config-kit`.

--- a/.changeset/update-author-repo-url.md
+++ b/.changeset/update-author-repo-url.md
@@ -1,0 +1,7 @@
+---
+"@cocopalm/oxc-formatter-config": patch
+"@cocopalm/oxc-linter-config": patch
+---
+
+- Update `author` field in `package.json` from `puffcocos` to `wjdgus09`.
+- Update `repository.url` in `package.json` to `https://github.com/wjdgus09/oxc-config-kit`.

--- a/packages/oxc-formatter-config/CHANGELOG.md
+++ b/packages/oxc-formatter-config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @puffcoco/oxc-formatter-config
 
+## 0.2.1
+
+### Patch Changes
+
+- 8e8728a: - Update `author` field in `package.json` from `puffcocos` to `wjdgus09`.
+  - Update `repository.url` in `package.json` to `https://github.com/wjdgus09/oxc-config-kit`.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/oxc-formatter-config/package.json
+++ b/packages/oxc-formatter-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocopalm/oxc-formatter-config",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "oxc formatter configuration",
   "keywords": [
     "config",

--- a/packages/oxc-formatter-config/package.json
+++ b/packages/oxc-formatter-config/package.json
@@ -2,30 +2,30 @@
   "name": "@cocopalm/oxc-formatter-config",
   "version": "0.2.0",
   "description": "oxc formatter configuration",
-  "author": "puffcocos",
+  "keywords": [
+    "config",
+    "formatter",
+    "oxc",
+    "oxfmt"
+  ],
   "license": "MIT",
-  "type": "module",
-  "main": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "author": "wjdgus09",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wjdgus09/oxc-config-kit"
+  },
   "files": [
     "dist"
   ],
-  "scripts": {
-    "build": "tsdown"
-  },
-  "keywords": [
-    "oxc",
-    "oxfmt",
-    "formatter",
-    "config"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/puffcocos/oxc-config-kit"
-  },
+  "type": "module",
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "scripts": {
+    "build": "tsdown"
   },
   "devDependencies": {
     "oxfmt": "^0.42.0",

--- a/packages/oxc-linter-config/CHANGELOG.md
+++ b/packages/oxc-linter-config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @puffcoco/oxc-linter-config
 
+## 0.2.4
+
+### Patch Changes
+
+- 8e8728a: - Update `author` field in `package.json` from `puffcocos` to `wjdgus09`.
+  - Update `repository.url` in `package.json` to `https://github.com/wjdgus09/oxc-config-kit`.
+
 ## 0.2.3
 
 ### Patch Changes

--- a/packages/oxc-linter-config/package.json
+++ b/packages/oxc-linter-config/package.json
@@ -8,10 +8,10 @@
     "oxc"
   ],
   "license": "MIT",
-  "author": "puffcocos",
+  "author": "wjdgus09",
   "repository": {
     "type": "git",
-    "url": "https://github.com/puffcocos/oxc-config-kit"
+    "url": "https://github.com/wjdgus09/oxc-config-kit"
   },
   "files": [
     "dist"

--- a/packages/oxc-linter-config/package.json
+++ b/packages/oxc-linter-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocopalm/oxc-linter-config",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "oxc linter configuration",
   "keywords": [
     "config",


### PR DESCRIPTION
## Summary
- `@cocopalm/oxc-formatter-config`, `@cocopalm/oxc-linter-config` 두 패키지의 `author`를 `puffcocos` → `wjdgus09`로 업데이트
- `repository.url`을 `https://github.com/wjdgus09/oxc-config-kit`로 변경
- patch 버전 bump: oxc-formatter-config 0.2.0 → 0.2.1, oxc-linter-config 0.2.3 → 0.2.4

## Test plan
- [ ] CHANGELOG 항목이 새 버전으로 정상 추가되었는지 확인
- [ ] 두 패키지의 `package.json`에서 author/repository URL이 모두 갱신되었는지 확인
- [ ] 릴리즈 워크플로우(CI)가 정상 통과하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)